### PR TITLE
タスクスケジュールの誤訳修正

### DIFF
--- a/translation-ja/scheduling.md
+++ b/translation-ja/scheduling.md
@@ -176,7 +176,7 @@ Laravelのコマンドスケジューラは、Laravel自身の中でコマンド
         return true;
     });
 
-`skip`メソッドは`when`をひっくり返したものです。`skip`メソッドへ渡したクロージャが`true`を返した時、スケジュールタスクは実行されます。
+`skip`メソッドは`when`をひっくり返したものです。`skip`メソッドへ渡したクロージャが`true`を返した時、スケジュールタスクは実行されません。
 
     $schedule->command('emails:send')->daily()->skip(function () {
         return true;


### PR DESCRIPTION
タスクスケジュール（真値テスト制約）の `skip` メソッド部分に誤りがありましたので修正しました。
https://readouble.com/laravel/6.x/ja/scheduling.html